### PR TITLE
Fix stream url append; fix unload player process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-multi-player",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "description": "Streaming Plugin",
     "cordova": {
         "id": "cordova-plugin-multi-player",

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="cordova-plugin-multi-player"
-    version="2.1.2">
+    version="2.1.3">
 
     <name>Multi Player Plugin</name>
     <description>Multi Player Plugin</description>


### PR DESCRIPTION
Browser fixes:
- The new param added to android, was causing an `,true` or `,false` to be appended to the stream url (eg: `streamUrl: 'https://mystream/listen'` could start playing an url `https://mystream/listen,true`)
- The unload process has been improved, after some error on the stream occured, could be sent a `LOADING` event after the `ERROR` event already been sent, this could cause problems when depending on this events
- Prevent any other event to be fired when the player is not initialized or is unloaded